### PR TITLE
v2/add send grid

### DIFF
--- a/app/[lang]/(header-layout)/fund/page.tsx
+++ b/app/[lang]/(header-layout)/fund/page.tsx
@@ -14,9 +14,9 @@ if (process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY == undefined) {
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLIC_KEY);
 
 export default function FundPage({
-  searchParams: { amount }
+  searchParams: { amount, id, title }
 }: {
-  searchParams: { amount: string };
+  searchParams: { amount: string, id: string, title: string };
 }) {
   const amountInt = parseInt(amount || '0');
   console.log('The converted amount', convertSubCurrency(amountInt));
@@ -34,7 +34,7 @@ export default function FundPage({
           currency: 'jpy'
         }}
       >
-        <CheckoutStripe amount={amountInt} />
+        <CheckoutStripe amount={amountInt} projectId={id} projectName={title} />
         {/* <CompletePayment /> */}
       </Elements>
     </>

--- a/app/[lang]/(header-layout)/payment-success/page.tsx
+++ b/app/[lang]/(header-layout)/payment-success/page.tsx
@@ -1,13 +1,19 @@
+'use client';
+
 export default function PaymentSuccess({
-  searchParams: { amount }
+  searchParams: { amount, to, name, error }
 }: {
-  searchParams: { amount: string };
+  searchParams: { amount: string; to: string; name: string, error: string };
 }) {
+  // TODO: Move the confirmation mail sending into another place
+
   return (
     <div className="bg-cream max-w-6xl mx-auto">
       <h1 className="text-4xl">Payment Success</h1>
-      <p>Thank you for your donation of</p>
+      <p>Thank you {name ? `${name} ` : ""}for your donation of</p>
       <p className="text-2xl">¥{amount}</p>
+      <small>{error ? `We couldn't send the confirmation email. Please contact us if you wish us to send it again. Error details: ${error}` : ""}</small>
+      <p>A confirmation has been sent to you via e-mail ({to}). Contact <a href="mailto: yann.klein@me.com">us</a> if any trouble.</p>
     </div>
   );
 }

--- a/app/[lang]/(header-layout)/projects/[id]/page.tsx
+++ b/app/[lang]/(header-layout)/projects/[id]/page.tsx
@@ -151,10 +151,11 @@ const ProjectDetails = async ({
       </div>
       <Funding.Card project={project} dict={dict}>
         <div className="hidden lg:block">
-          <Funding.AmountSelector dict={dict} />
+          <Funding.AmountSelector dict={dict} project={project} />
         </div>
         <div className="block md:hidden">
           <FundModal
+            project={project}
             count={count}
             amount={amount}
             goal={goal}

--- a/app/_components/CheckoutStripe.tsx
+++ b/app/_components/CheckoutStripe.tsx
@@ -8,12 +8,14 @@ import {
 } from '@stripe/react-stripe-js';
 import { convertSubCurrency } from '@/lib/convertSubCurrency';
 
-const CheckoutStripe = ({ amount }: { amount: number }) => {
+const CheckoutStripe = ({ amount, projectId, projectName }: { amount: number, projectId: string, projectName: string }) => {
   const stripe = useStripe();
   const elements = useElements();
   const [errorMessages, setErrorMessages] = useState<string>();
   const [clientSecret, setClientSecret] = useState('');
   const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [donator, setDonator] = useState('');
 
   useEffect(() => {
     const fetchClientSecret = async () => {
@@ -45,12 +47,12 @@ const CheckoutStripe = ({ amount }: { amount: number }) => {
       setLoading(false);
       return;
     }
-
+    
     const { error } = await stripe.confirmPayment({
       elements,
       clientSecret,
       confirmParams: {
-        return_url: `http://localhost:3000/payment-success?amount=${amount}`
+        return_url: `${process.env.NEXT_PUBLIC_WEBSITE_URL}/api/send-confirmation?amount=${amount}&to=${email}&name=${donator}&projectId=${projectId}&projectName=${projectName}`
       }
     });
 
@@ -70,8 +72,16 @@ const CheckoutStripe = ({ amount }: { amount: number }) => {
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-cream p-12 w-3/4 mx-auto rounded-md my-10"
+      className="bg-cream p-4 sm:p-12 w-3/4 mx-auto rounded-md my-10"
     >
+      <div className="mb-3">
+        <label htmlFor="email">Your e-mail</label>
+        <input value={email} onChange={(e) => setEmail(e.target.value)} id="email" className="p-2 w-full" type="email" name="email" placeholder="adriana@crowdcoded.org"/>
+      </div>
+      <div className="mb-3">
+        <label htmlFor="donator">Your name (optional)</label>
+        <input value={donator} onChange={(e) => setDonator(e.target.value)} id="donator" className="p-2 w-full" type="text" name="donator" placeholder="Adriana Ito" />
+      </div>
       {clientSecret && <PaymentElement />}
       <button
         type="submit"

--- a/app/_components/FeaturedProject.tsx
+++ b/app/_components/FeaturedProject.tsx
@@ -70,6 +70,7 @@ const Project: React.FC<{ project: ProjectProps; dict: any }> = async ({
             <p>{dict.landing.featured.learnMore}</p>
           </ButtonLink>
           <FundModal
+            project={project}
             count={count}
             amount={amount}
             goal={goal}

--- a/app/_components/FundModal.tsx
+++ b/app/_components/FundModal.tsx
@@ -3,8 +3,10 @@ import Markdown from 'react-markdown';
 import { Modal } from './Modal';
 import DonationProgress from './DonationProgress';
 import { Funding } from './Funding';
+import { ProjectProps } from '../types';
 
 type FundModalProps = {
+  project: ProjectProps;
   count: number;
   amount: number;
   goal: number;
@@ -14,6 +16,7 @@ type FundModalProps = {
 };
 
 const FundModal: React.FC<FundModalProps> = ({
+  project,
   count,
   amount,
   goal,
@@ -51,6 +54,7 @@ const FundModal: React.FC<FundModalProps> = ({
           <Funding.AmountSelector
             dict={dict}
             className="grid grid-cols-2 gap-4 mb-3"
+            project={project}
           />
         </div>
       </Modal.Content>

--- a/app/_components/Funding/FundingAmountSelector.tsx
+++ b/app/_components/Funding/FundingAmountSelector.tsx
@@ -5,13 +5,14 @@ import { useRouter } from 'next/navigation';
 import AmountRadioButton from './AmountRadioButton';
 import { cn } from '@/lib/twMerge';
 
-export const FundingAmountSelector = ({ dict, className = '' }) => {
+export const FundingAmountSelector = ({ dict, project, className = '' }) => {
+  const { id, title } = project;
   const router = useRouter();
   const [selectedAmount, setSelectedAmount] = React.useState(5000);
   const [freeInputAmount, setFreeInputAmount] = React.useState(0);
 
   const fundingAmount = selectedAmount ? selectedAmount : freeInputAmount || 0;
-  const fundUrl = '/fund?amount=' + fundingAmount;
+  const fundUrl = `/fund?amount=${fundingAmount}&id=${id}&title=${title}`;
 
   const handleFreeInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const amount = Number.parseInt(e.currentTarget.value, 10);

--- a/app/api/send-confirmation/route.ts
+++ b/app/api/send-confirmation/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
       <img height="80" src="https://www.crowdcoded.org/logo.png" alt="crowd coded logo">
       <h1>CROWD CODED</h1>
     </div>
-    <p>Dear ${name},</p>
+    <p>Hi ${name ? name : "there"},</p>
     <p>
       Thank you for support ${projectName} project with your donation of ${amount}!<br/>
       You can now check your positive impact on the <a style="text-decoration: none; color: #55A9BB" href="https://www.crowdcoded.org/en/projects/${projectId}">project funding status<a/> on our website.<br/>

--- a/app/api/send-confirmation/route.ts
+++ b/app/api/send-confirmation/route.ts
@@ -1,0 +1,53 @@
+import sendgrid from '@sendgrid/mail';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { to, name, amount, projectId, projectName } = {
+    to: req.nextUrl.searchParams.get('to'),
+    name: req.nextUrl.searchParams.get('name'),
+    amount: req.nextUrl.searchParams.get('amount'),
+    projectId: req.nextUrl.searchParams.get('projectId'),
+    projectName: req.nextUrl.searchParams.get('projectName')
+  };
+  const htmlContent = `
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+    <div style="font-family: sans-serif; font-size: 20px;">
+      <div style="display: flex; align-items: center; gap: 16px; font-family: Bebas Neue, sans-serif; margin: 16px 8px" >
+      <img height="80" src="https://www.crowdcoded.org/logo.png" alt="crowd coded logo">
+      <h1>CROWD CODED</h1>
+    </div>
+    <p>Dear ${name},</p>
+    <p>
+      Thank you for support ${projectName} project with your donation of ${amount}!<br/>
+      You can now check your positive impact on the <a style="text-decoration: none; color: #55A9BB" href="https://www.crowdcoded.org/en/projects/${projectId}">project funding status<a/> on our website.<br/>
+      Best regards,
+    </p>
+    <p>Yann and Adriana from <a style="text-decoration: none; color: #55A9BB" href="https://www.crowdcoded.org/">Crowd Coded</a></p>
+    </div>
+  `;
+  const msg = {
+    to: to,
+    from: 'yann.klein@me.com',
+    subject: `Your funding of ${amount} has been received!`,
+    html: htmlContent
+  };
+
+  sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
+  try {
+    // don't send e-mail if development environment
+    if (process.env.NODE_ENV === 'production') {
+      await sendgrid.send(msg);
+    } else {
+      console.log("Message sent! (actual e-mailing disabled in development)", msg);
+    }
+    return NextResponse.redirect(
+      `${process.env.NEXT_PUBLIC_WEBSITE_URL}/payment-success?amount=${amount}&to=${to}&name=${name}`
+    );
+  } catch (error) {
+    return NextResponse.redirect(
+      `${process.env.NEXT_PUBLIC_WEBSITE_URL}/payment-success?amount=${amount}&to=${to}&name=${name}error=${error.message}`
+    );
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  // reactStrictMode: false,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@prisma/client": "^5.19.1",
+        "@sendgrid/mail": "^8.1.3",
         "@stripe/react-stripe-js": "^2.8.0",
         "@stripe/stripe-js": "^1.54.2",
         "@vercel/postgres": "^0.10.0",
@@ -469,6 +470,41 @@
         "@prisma/debug": "5.19.1"
       }
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.3.tgz",
+      "integrity": "sha512-mRwTticRZIdUTsnyzvlK6dMu3jni9ci9J+dW/6fMMFpGRAJdCJlivFVYQvqk8kRS3RnFzS7sf6BSmhLl1ldDhA==",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.3.tgz",
+      "integrity": "sha512-Wg5iKSUOER83/cfY6rbPa+o3ChnYzWwv1OcsR8gCV8SKi+sUPIMroildimlnb72DBkQxcbylxng1W7f0RIX7MQ==",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.3",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@stripe/react-stripe-js": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-2.8.0.tgz",
@@ -654,6 +690,11 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -689,6 +730,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/bail": {
@@ -916,6 +967,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -993,6 +1055,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1007,6 +1077,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -1137,6 +1215,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -1151,6 +1248,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2015,6 +2125,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2573,6 +2702,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@prisma/client": "^5.19.1",
+    "@sendgrid/mail": "^8.1.3",
     "@stripe/react-stripe-js": "^2.8.0",
     "@stripe/stripe-js": "^1.54.2",
     "@vercel/postgres": "^0.10.0",


### PR DESCRIPTION
- add sendgrid and commented out restrict mode next setting
- create send-confirmation api route
- add send confirmation step between payment completed and payment success page
- modify props to include project id and title in payment pipeline
